### PR TITLE
fix: set hostname to `meta.log.group` if `raw_event` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file documents all notable changes in `LogDNA CloudWatch Lambda Function`. The release numbering uses [semantic versioning](http://semver.org).
 
+## v2.2.1 - Released on August 21, 2020
+* Set hostname to `meta.log.group` if `raw_event` is enabled
+
 ## v2.2.0 - Released on June 9, 2020
 * Add `LOG_RAW_EVENT` environment variable option to set `line` to raw `event.message`
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,8 @@ const sendLine = (payload, config, callback) => {
     if (!config.key) return callback('Missing LogDNA Ingestion Key');
 
     // Set Hostname
-    const hostname = config.hostname || JSON.parse(payload[0].line).log.group;
+    const logGroup = config.log_raw_event ? payload[0].meta.log.group : JSON.parse(payload[0].line).log.group;
+    const hostname = config.hostname || logGroup;
 
     // Prepare HTTP Request Options
     const options = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-cloudwatch",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Lambda Functions to Stream Logs from AWS CloudWatch to LogDNA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
According to [this issue](#24), when `raw_event` is enabled, trying to parse the line is causing problem. This Pull Request addresses #24 

Ref: LOG-6995
Semver: patch